### PR TITLE
Charter, expectations and responsibilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
-# advisory-group
-Enterprise Advisory Group
+# Enterprise Advisory Group
+
+The Enterprise Advisory Group is a group of corporate representatives in roles of leadership responsible managing for large-scale deployments of Node.js in an Enterprise environment. As a group, we strive to provide timely feedback to the [TSC](https://github.com/nodejs/TSC), the [CommComm](https://github.com/nodejs/community-committee), the [Node.js project](https://github.com/nodejs/node) and the Node.js Foundation about the unique needs surrounding running Node.js in an Enterprise environment.
+
+This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee). Thank you for your interest and support. Please [create an issue](https://github.com/nodejs/user-feedback/issues) in this repo if you are interested in dedicating 5+ hours a month to during the formation process.
+
+### Governance and Contributing
+The Enterprise Advisory Group has adopted the core governance and contributing policies of Node.js. This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee).
+
+Members are expected to be able to provide feedback on proposed changes in the Node.js project and gather input on how those changes will impact teams, business goals and application performance at scale and in the Enterprise context. Members are expected to attend regular advisory meetings to provide feedback and respond to occational outreach requests. 
+
+### Enterprise Advisory Group Team Members
+
+* [dshaw](https://github.com/dshaw) - **Dan Shaw** &lt;dshaw@dshaw.com&gt; - Node.js End User Feedback coordinator - Node.js at Large ✨
+* [jasnell](https://github.com/jasnell) - **James Snell** - TSC - nearForm
+* **Scott Anderson** - MasterCard
+* **Chris Castle** - Heroku
+* **Monica Ene-Pietrosanu** - Intel
+* **Scott Hammond** - Joyent
+* **Trevor Livingston** - Expedia Group / HomeAway
+* **Todd Moore** - IBM
+* **Ahmad Nassri** - TELUS
+* **Sarah Novotny** - Google
+* **Gaurav Seth** - Microsoft
+* **Laurie Voss** - npm
+
+## Additional Context
+
+The organization and formation of this initiative was kicked off by James Snell ([@jasnell](https://github.com/jasnell)) and Dan Shaw ([@dshaw](https://github.com/dshaw)). We are greatful for their leadership.
+
+* [#user-feedback/18](https://github.com/nodejs/user-feedback/issues/18) Enterprise Advisory/Feedback Group

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enterprise Advisory Group
 
-The Enterprise Advisory Group is a group of corporate representatives in roles of leadership responsible managing for large-scale deployments of Node.js in an Enterprise environment. As a group, we strive to provide timely feedback to the [TSC](https://github.com/nodejs/TSC), the [CommComm](https://github.com/nodejs/community-committee), the [Node.js project](https://github.com/nodejs/node) and the Node.js Foundation about the unique needs surrounding running Node.js in an Enterprise environment.
+The Enterprise Advisory Group consists of corporate representatives in leadership roles responsible for managing for large-scale deployments of Node.js in an Enterprise environment. We strive to provide timely feedback to the [TSC](https://github.com/nodejs/TSC), the [CommComm](https://github.com/nodejs/community-committee), the [Node.js project](https://github.com/nodejs/node) and the Node.js Foundation about the needs of Node.js Enterprise users.
 
 This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee). Thank you for your interest and support. Please [create an issue](https://github.com/nodejs/user-feedback/issues) in this repo if you are interested in dedicating 5+ hours a month to during the formation process.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The Enterprise Advisory Group consists of corporate representatives in leadership roles responsible for managing for large-scale deployments of Node.js in an Enterprise environment. We strive to provide timely feedback to the [TSC](https://github.com/nodejs/TSC), the [CommComm](https://github.com/nodejs/community-committee), the [Node.js project](https://github.com/nodejs/node) and the Node.js Foundation about the needs of Node.js Enterprise users.
 
-This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee). Thank you for your interest and support. Please [create an issue](https://github.com/nodejs/user-feedback/issues) in this repo if you are interested in dedicating 5+ hours a month to during the formation process.
+Thank you for your interest and support. Please [create an issue](https://github.com/nodejs/user-feedback/issues) in this repo if you are interested in dedicating 5+ hours a month during the formation process.
 
 ### Governance and Contributing
 The Enterprise Advisory Group has adopted the core governance and contributing policies of Node.js. This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The Enterprise Advisory Group consists of corporate representatives in leadershi
 Thank you for your interest and support. Please [create an issue](https://github.com/nodejs/user-feedback/issues) in this repo if you are interested in dedicating 5+ hours a month during the formation process.
 
 ### Governance and Contributing
-The Enterprise Advisory Group has adopted the core governance and contributing policies of Node.js. This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee).
+The Enterprise Advisory Group has adopted the core governance and contributing policies of Node.js. This group is a part of the [Node.js End User Feedback Initiative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee).
 
 Members are expected to provide feedback on how proposed changes in the Node.js project will affect Enterprise teams, business goals, and application performance at scale. Members attend regular group meetings to provide feedback and respond to occasional outreach requests. 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Thank you for your interest and support. Please [create an issue](https://github
 ### Governance and Contributing
 The Enterprise Advisory Group has adopted the core governance and contributing policies of Node.js. This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee).
 
-Members are are expected to provide feedback on how proposed changes in the Node.js project will affect Enterprise teams, business goals, and application performance at scale. Members attend regular group meetings to provide feedback and respond to occasional outreach requests. 
+Members are expected to provide feedback on how proposed changes in the Node.js project will affect Enterprise teams, business goals, and application performance at scale. Members attend regular group meetings to provide feedback and respond to occasional outreach requests. 
 
 ### Enterprise Advisory Group Team Members
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This group is a part of the [Node.js End User Feedback Inititative](https://gith
 ### Governance and Contributing
 The Enterprise Advisory Group has adopted the core governance and contributing policies of Node.js. This group is a part of the [Node.js End User Feedback Inititative](https://github.com/nodejs/user-feedback) which is under the charter of the [Node.js Community Committee (CommComm)](https://github.com/nodejs/community-committee).
 
-Members are expected to be able to provide feedback on proposed changes in the Node.js project and gather input on how those changes will impact teams, business goals and application performance at scale and in the Enterprise context. Members are expected to attend regular advisory meetings to provide feedback and respond to occational outreach requests. 
+Members are are expected to provide feedback on how proposed changes in the Node.js project will affect Enterprise teams, business goals, and application performance at scale. Members attend regular group meetings to provide feedback and respond to occasional outreach requests. 
 
 ### Enterprise Advisory Group Team Members
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Members are expected to provide feedback on how proposed changes in the Node.js 
 ### Enterprise Advisory Group Team Members
 
 * [dshaw](https://github.com/dshaw) - **Dan Shaw** &lt;dshaw@dshaw.com&gt; - Node.js End User Feedback coordinator - Node.js at Large ✨
-* [jasnell](https://github.com/jasnell) - **James Snell** - TSC - nearForm
 * **Scott Anderson** - MasterCard
 * **Chris Castle** - Heroku
 * **Monica Ene-Pietrosanu** - Intel

--- a/README.md
+++ b/README.md
@@ -23,9 +23,3 @@ Members are are expected to provide feedback on how proposed changes in the Node
 * **Sarah Novotny** - Google
 * **Gaurav Seth** - Microsoft
 * **Laurie Voss** - npm
-
-## Additional Context
-
-The organization and formation of this initiative was kicked off by James Snell ([@jasnell](https://github.com/jasnell)) and Dan Shaw ([@dshaw](https://github.com/dshaw)). We are greatful for their leadership.
-
-* [#user-feedback/18](https://github.com/nodejs/user-feedback/issues/18) Enterprise Advisory/Feedback Group


### PR DESCRIPTION
Added context for the Enterprise Advisory Group as a part of @nodejs/user-feedback under the @nodejs/community-committee charter.